### PR TITLE
Fix midtrans-python-client to support windows environment

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding='utf-8') as fh:
     long_description = fh.read()
 
 pkg_req = [


### PR DESCRIPTION
To support Windows.
Without this fix, `UnicodeDecodeError: 'cp932' codec can't decode byte 0xef in position 515: illegal multibyte sequence` will occor when `pip install`