### PR TITLE
Allow custom header in Snap

### DIFF
--- a/midtransclient/helpers.py
+++ b/midtransclient/helpers.py
@@ -1,0 +1,9 @@
+import sys
+
+_PYTHON_VERSION = sys.version_info[:2]
+
+def merge_two_dicts(x, y):
+    """Given two dictionaries, merge them into a new dict as a shallow copy."""
+    z = x.copy()
+    z.update(y)
+    return z

--- a/midtransclient/snap.py
+++ b/midtransclient/snap.py
@@ -24,7 +24,7 @@ class Snap:
     def api_config(self, new_value):
         self.__api_config = new_value
 
-    def create_transaction(self,parameters=dict()):
+    def create_transaction(self,parameters=dict(),headers=dict()):
         """
         Trigger API call to Snap API
         :param parameters: dictionary of SNAP API JSON body as parameter, will be converted to JSON
@@ -38,17 +38,18 @@ class Snap:
             'post',
             self.api_config.server_key,
             api_url,
-            parameters)
+            parameters,
+            headers)
         return response_dict
 
-    def create_transaction_token(self,parameters=dict()):
+    def create_transaction_token(self,parameters=dict(),headers=dict()):
         """
         Wrapper method that call `create_transaction` and directly :return: `token`
         """
-        return self.create_transaction(parameters)['token']
+        return self.create_transaction(parameters, headers)['token']
 
-    def create_transaction_redirect_url(self,parameters=dict()):
+    def create_transaction_redirect_url(self,parameters=dict(),headers=dict()):
         """
         Wrapper method that call `create_transaction` and directly :return: `redirect_url`
         """
-        return self.create_transaction(parameters)['redirect_url']
+        return self.create_transaction(parameters, headers)['redirect_url']

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ test_req = pkg_req + [
 
 setuptools.setup(
     name="midtransclient",
-    version="1.1.1",
+    version="1.1.2",
     author="Rizda Prasetya",
     author_email="rizda.prasetya@midtrans.com",
     license='MIT',


### PR DESCRIPTION
Since Midtrans has a feature to [override notification URL](https://snap-docs.midtrans.com/#override-notification-url) I think it would be a great addition to this library


- allow custom header to be sent in `http_client.py` class
- update `Snap` class to allow custom header to Midtrans API
- add helper to check python version
- bump version to 1.1.2