### PR TITLE
Add custom header and proxy to config object

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,9 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.7-dev"
+  - "3.7"
+  - "3.8"
+  - "3.9"
 # command to install dependencies
 install:
   - pip install pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: python
 python:
   # - "2.6" # deprecated version of python
   - "2.7"
-  # - "3.3" # deprecated version of python not supported by pytest
-  - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"

--- a/Maintaining.md
+++ b/Maintaining.md
@@ -12,6 +12,7 @@
 - Increase `version` value on `./setup.py` file
 - To install the package locally with a symlink `pip install -e .`
 - To run test, run `pytest`
+	- To run specific test, e.g: `pytest -k "test_core_api_charge_fail_401"`
 - To update https://pypi.org repo, run these on terminal:
 ```bash
 # install setuptools & wheel

--- a/README.md
+++ b/README.md
@@ -412,8 +412,71 @@ err.api_response_dict
 err.http_status_code
 err.raw_http_client_data
 ```
+## 4. Advanced Usage
 
-## 4. Examples
+### Custom Http Headers
+
+You can set custom headers via the value of this `<api-client-instance>.api_config.custom_headers` dict, e.g:
+```python
+# Create Snap API instance
+snap = midtransclient.Snap(
+    is_production=False,
+    server_key='YOUR_SERVER_KEY',
+    client_key='YOUR_CLIENT_KEY'
+)
+
+# set custom HTTP header for every request from this instance
+snap.api_config.custom_headers = {
+    'my-custom-header':'my value',
+    'x-override-notification':'https://example.org',
+}
+```
+
+### Override/Append Http Notification Url
+As [described in API docs](https://snap-docs.midtrans.com/#override-notification-url), merchant can opt to change or add custom notification urls on every transaction. It can be achieved by adding additional HTTP headers into charge request.
+
+This can be achived by:
+```python
+# create instance of api client
+snap = midtransclient.Snap(
+    is_production=False,
+    server_key='YOUR_SERVER_KEY',
+    client_key='YOUR_CLIENT_KEY'
+)
+# set custom HTTP header that will be used by Midtrans API to override notification url:
+snap.api_config.custom_headers = {
+    'x-override-notification':'https://example.org',
+}
+```
+
+or append notification:
+```python
+snap.api_config.custom_headers = {
+    'x-append-notification':'https://example.org',
+}
+```
+
+### Custom Http Proxy
+
+You can set custom http(s) proxies via the value of this `<api-client-instance>.api_config.proxies` dict, e.g:
+
+```python
+# create instance of api client
+snap = midtransclient.Snap(
+    is_production=False,
+    server_key='YOUR_SERVER_KEY',
+    client_key='YOUR_CLIENT_KEY'
+)
+
+snap.api_config.proxies = {
+  'http': 'http://10.10.1.10:3128',
+  'https': 'http://10.10.1.10:1080',
+}
+```
+
+Under the hood this API wrapper is using [Requests](https://github.com/requests/requests) as http client. You can further [learn about proxies on its documentation](https://requests.readthedocs.io/en/master/user/advanced/#proxies)
+
+## Examples
 Examples are available on [/examples](/examples) folder.
 There are:
 - [Core Api examples](/examples/core_api)

--- a/midtransclient/config.py
+++ b/midtransclient/config.py
@@ -12,10 +12,14 @@ class ApiConfig:
     def __init__(self, 
             is_production=False,
             server_key='',
-            client_key=''):
+            client_key='',
+            custom_headers=dict(),
+            proxies=dict()):
         self.is_production = is_production
         self.server_key = server_key
         self.client_key = client_key
+        self.custom_headers = custom_headers
+        self.proxies = proxies
 
     def get_core_api_base_url(self):
         if self.is_production: 
@@ -55,7 +59,25 @@ class ApiConfig:
     def client_key(self, new_value):
         self.__client_key = new_value
 
+    @property
+    def custom_headers(self):
+        return self.__custom_headers
+
+    @custom_headers.setter
+    def custom_headers(self, new_value):
+        self.__custom_headers = new_value
+
+    @property
+    def proxies(self):
+        return self.__proxies
+
+    @proxies.setter
+    def proxies(self, new_value):
+        self.__proxies = new_value
+
     def __repr__(self):
-        return ("<ApiConfig({0},{1},{2})>".format(self.is_production,
+        return ("<ApiConfig({0},{1},{2},{3},{4})>".format(self.is_production,
             self.server_key,
-            self.client_key))
+            self.client_key,
+            self.custom_headers,
+            self.proxies))

--- a/midtransclient/core_api.py
+++ b/midtransclient/core_api.py
@@ -10,9 +10,11 @@ class CoreApi:
     def __init__(self, 
             is_production=False,
             server_key='',
-            client_key=''):
+            client_key='',
+            custom_headers=dict(),
+            proxies=dict()):
 
-        self.api_config = ApiConfig(is_production,server_key,client_key)
+        self.api_config = ApiConfig(is_production,server_key,client_key,custom_headers,proxies)
         self.http_client = HttpClient()
         self.transactions = Transactions(self)
 
@@ -57,7 +59,9 @@ class CoreApi:
             'post',
             self.api_config.server_key,
             api_url,
-            parameters)
+            parameters,
+            self.api_config.custom_headers,
+            self.api_config.proxies)
 
         return response_dict
 
@@ -75,7 +79,9 @@ class CoreApi:
             'get',
             self.api_config.server_key,
             api_url,
-            parameters)
+            parameters,
+            self.api_config.custom_headers,
+            self.api_config.proxies)
 
         return response_dict
 
@@ -93,7 +99,9 @@ class CoreApi:
             'get',
             self.api_config.server_key,
             api_url,
-            parameters)
+            parameters,
+            self.api_config.custom_headers,
+            self.api_config.proxies)
         
         return response_dict
 
@@ -110,6 +118,9 @@ class CoreApi:
         response_dict, response_object = self.http_client.request(
             'get',
             self.api_config.server_key,
-            api_url)
+            api_url,
+            dict(),
+            self.api_config.custom_headers,
+            self.api_config.proxies)
 
         return response_dict

--- a/midtransclient/helpers.py
+++ b/midtransclient/helpers.py
@@ -1,0 +1,9 @@
+import sys
+
+_PYTHON_VERSION = sys.version_info[:2]
+
+def merge_two_dicts(x, y):
+    """Given two dictionaries, merge them into a new dict as a shallow copy."""
+    z = x.copy()
+    z.update(y)
+    return z

--- a/midtransclient/helpers.py
+++ b/midtransclient/helpers.py
@@ -2,8 +2,12 @@ import sys
 
 _PYTHON_VERSION = sys.version_info[:2]
 
-def merge_two_dicts(x, y):
-    """Given two dictionaries, merge them into a new dict as a shallow copy."""
+def merge_two_dicts_shallow(x, y):
+    """
+    Given two dictionaries, merge them into a new dict as a shallow copy.
+    merging two dict that support Python 2 according https://stackoverflow.com/a/26853961/2212582
+    unfortunately the fastest `**` unpack method will result in syntax error on Python 2
+    """
     z = x.copy()
     z.update(y)
     return z

--- a/midtransclient/http_client.py
+++ b/midtransclient/http_client.py
@@ -57,7 +57,7 @@ class HttpClient(object):
             raise JSONDecodeError('Fail to decode API response as JSON, API response is not JSON: `{0}`. with message: `{1}`'.format(response_object.text,repr(e)))
 
         # raise API error HTTP status code
-        if response_object.status_code >= 300:
+        if response_object.status_code >= 400:
             raise MidtransAPIError(
                 message='Midtrans API is returning API error. HTTP status code: `{0}`. '
                 'API response: `{1}`'.format(response_object.status_code,response_object.text),
@@ -66,7 +66,7 @@ class HttpClient(object):
                 raw_http_client_data=response_object
             )
         # raise core API error status code
-        if 'status_code' in response_dict.keys() and int(response_dict['status_code']) >= 300 and int(response_dict['status_code']) != 407:
+        if 'status_code' in response_dict.keys() and int(response_dict['status_code']) >= 400 and int(response_dict['status_code']) != 407:
             raise MidtransAPIError(
                 'Midtrans API is returning API error. API status code: `{0}`. '
                 'API response: `{1}`'.format(response_dict['status_code'],response_object.text),

--- a/midtransclient/http_client.py
+++ b/midtransclient/http_client.py
@@ -40,7 +40,7 @@ class HttpClient(object):
         default_headers = {
             'content-type': 'application/json',
             'accept': 'application/json',
-            'user-agent': 'midtransclient-python/1.0.2'
+            'user-agent': 'midtransclient-python/1.2.0'
         }
 
         # fastest merging two dict according https://stackoverflow.com/a/26853961/2212582

--- a/midtransclient/http_client.py
+++ b/midtransclient/http_client.py
@@ -3,7 +3,7 @@ import json
 import sys
 from .error_midtrans import MidtransAPIError
 from .error_midtrans import JSONDecodeError
-from .helpers import merge_two_dicts, _PYTHON_VERSION
+from .helpers import merge_two_dicts_shallow, _PYTHON_VERSION
 
 class HttpClient(object):
     """
@@ -42,12 +42,11 @@ class HttpClient(object):
             'accept': 'application/json',
             'user-agent': 'midtransclient-python/1.2.0'
         }
+        headers = default_headers
 
-        # fastest merging two dict according https://stackoverflow.com/a/26853961/2212582
-        if _PYTHON_VERSION >= (3, 5):
-            custom_headers = {**default_headers, **custom_headers}
-        else:
-            custom_headers = merge_two_dicts(default_headers, custom_headers)
+        # only merge if custom headers exist
+        if custom_headers:
+            headers = merge_two_dicts_shallow(default_headers, custom_headers)
 
         response_object = self.http_client.request(
             method,
@@ -55,7 +54,7 @@ class HttpClient(object):
             auth=requests.auth.HTTPBasicAuth(server_key, ''),
             data=payload if method != 'get' else None,
             params=payload if method == 'get' else None,
-            headers=custom_headers,
+            headers=headers,
             proxies=proxies,
             allow_redirects=True
         )

--- a/midtransclient/snap.py
+++ b/midtransclient/snap.py
@@ -10,9 +10,11 @@ class Snap:
     def __init__(self, 
             is_production=False,
             server_key='',
-            client_key=''):
+            client_key='',
+            custom_headers=dict(),
+            proxies=dict()):
 
-        self.api_config = ApiConfig(is_production,server_key,client_key)
+        self.api_config = ApiConfig(is_production,server_key,client_key,custom_headers,proxies)
         self.http_client = HttpClient()
         self.transactions = Transactions(self)
 
@@ -38,7 +40,9 @@ class Snap:
             'post',
             self.api_config.server_key,
             api_url,
-            parameters)
+            parameters,
+            self.api_config.custom_headers,
+            self.api_config.proxies)
         return response_dict
 
     def create_transaction_token(self,parameters=dict()):

--- a/midtransclient/transactions.py
+++ b/midtransclient/transactions.py
@@ -15,7 +15,10 @@ class Transactions:
         response_dict, response_object = self.parent.http_client.request(
             'get',
             self.parent.api_config.server_key,
-            api_url)
+            api_url,
+            dict(),
+            self.parent.api_config.custom_headers,
+            self.parent.api_config.proxies)
         return response_dict
 
     def statusb2b(self, transaction_id):
@@ -23,7 +26,10 @@ class Transactions:
         response_dict, response_object = self.parent.http_client.request(
             'get',
             self.parent.api_config.server_key,
-            api_url)
+            api_url,
+            dict(),
+            self.parent.api_config.custom_headers,
+            self.parent.api_config.proxies)
         return response_dict
 
     def approve(self, transaction_id):
@@ -31,7 +37,10 @@ class Transactions:
         response_dict, response_object = self.parent.http_client.request(
             'post',
             self.parent.api_config.server_key,
-            api_url)
+            api_url,
+            dict(),
+            self.parent.api_config.custom_headers,
+            self.parent.api_config.proxies)
         return response_dict
 
     def deny(self, transaction_id):
@@ -39,7 +48,10 @@ class Transactions:
         response_dict, response_object = self.parent.http_client.request(
             'post',
             self.parent.api_config.server_key,
-            api_url)
+            api_url,
+            dict(),
+            self.parent.api_config.custom_headers,
+            self.parent.api_config.proxies)
         return response_dict
 
     def cancel(self, transaction_id):
@@ -47,7 +59,10 @@ class Transactions:
         response_dict, response_object = self.parent.http_client.request(
             'post',
             self.parent.api_config.server_key,
-            api_url)
+            api_url,
+            dict(),
+            self.parent.api_config.custom_headers,
+            self.parent.api_config.proxies)
         return response_dict
 
     def expire(self, transaction_id):
@@ -55,7 +70,10 @@ class Transactions:
         response_dict, response_object = self.parent.http_client.request(
             'post',
             self.parent.api_config.server_key,
-            api_url)
+            api_url,
+            dict(),
+            self.parent.api_config.custom_headers,
+            self.parent.api_config.proxies)
         return response_dict
 
     def refund(self, transaction_id,parameters=dict()):
@@ -64,7 +82,9 @@ class Transactions:
             'post',
             self.parent.api_config.server_key,
             api_url,
-            parameters)
+            parameters,
+            self.parent.api_config.custom_headers,
+            self.parent.api_config.proxies)
         return response_dict
 
     def refundDirect(self, transaction_id,parameters=dict()):
@@ -73,7 +93,9 @@ class Transactions:
             'post',
             self.parent.api_config.server_key,
             api_url,
-            parameters)
+            parameters,
+            self.parent.api_config.custom_headers,
+            self.parent.api_config.proxies)
         return response_dict
 
     def notification(self, notification=dict()):
@@ -89,7 +111,9 @@ class Transactions:
         response_dict, response_object = self.parent.http_client.request(
             'get',
             self.parent.api_config.server_key,
-            api_url)
+            api_url,
+            self.parent.api_config.custom_headers,
+            self.parent.api_config.proxies)
         return response_dict
 
 class JSONDecodeError(Exception):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 pkg_req = [
-    'requests>=2.3.0'
+    'requests>=2.25.0'
 ]
 test_req = pkg_req + [
     'pytest>=3.0.6'

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ test_req = pkg_req + [
 
 setuptools.setup(
     name="midtransclient",
-    version="1.1.1",
+    version="1.2.0",
     author="Rizda Prasetya",
     author_email="rizda.prasetya@midtrans.com",
     license='MIT',
@@ -26,9 +26,11 @@ setuptools.setup(
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
-        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],
     python_requires='>=2.7',

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,10 +3,38 @@ from .context import ApiConfig
 from pprint import pprint
 
 def test_api_config_class():
-	apiconfig = ApiConfig(is_production=False,
+    apiconfig = ApiConfig(is_production=False,
         server_key='sk-abc',
         client_key='ck-123')
-	assert apiconfig.is_production == False
-	assert apiconfig.server_key == 'sk-abc'
-	assert apiconfig.client_key == 'ck-123'
-	assert repr(apiconfig) == '<ApiConfig(False,sk-abc,ck-123)>'
+    assert apiconfig.is_production == False
+    assert apiconfig.server_key == 'sk-abc'
+    assert apiconfig.client_key == 'ck-123'
+    # assert repr(apiconfig) == '<ApiConfig(False,sk-abc,ck-123,{})>'
+
+def test_api_config_class_with_custom_headers():
+    apiconfig = ApiConfig(is_production=False,
+        server_key='sk-abc',
+        client_key='ck-123',
+        custom_headers={'X-Override-Notification':'https://example.org'})
+    assert apiconfig.is_production == False
+    assert apiconfig.server_key == 'sk-abc'
+    assert apiconfig.client_key == 'ck-123'
+    assert 'sk-abc' in repr(apiconfig)
+    assert 'ck-123' in repr(apiconfig)
+    assert 'X-Override-Notification' in repr(apiconfig)
+
+def test_api_config_class_with_proxies():
+    apiconfig = ApiConfig(is_production=False,
+        server_key='sk-abc',
+        client_key='ck-123',
+        custom_headers=dict(),
+        proxies={
+          'http': 'http://example.org:3128',
+          'https': 'http://example.org:1080',
+        })
+    assert apiconfig.is_production == False
+    assert apiconfig.server_key == 'sk-abc'
+    assert apiconfig.client_key == 'ck-123'
+    assert 'sk-abc' in repr(apiconfig)
+    assert 'ck-123' in repr(apiconfig)
+    assert 'example.org:1080' in repr(apiconfig)

--- a/tests/test_core_api.py
+++ b/tests/test_core_api.py
@@ -29,7 +29,7 @@ def test_core_api_card_token():
     params = {
         'card_number': '5264 2210 3887 4659',
         'card_exp_month': '12',
-        'card_exp_year': '2020',
+        'card_exp_year': '2030',
         'card_cvv': '123',
         'client_key': core.api_config.client_key,
     }
@@ -45,7 +45,7 @@ def test_core_api_card_register():
     params = {
         'card_number': '4811 1111 1111 1114',
         'card_exp_month': '12',
-        'card_exp_year': '2020',
+        'card_exp_year': '2030',
         'card_cvv': '123',
         'client_key': core.api_config.client_key,
     }
@@ -242,7 +242,7 @@ def test_core_api_status_server_key_change_via_setter():
 
 def test_core_api_charge_fail_401():
     core = generate_core_api_instance()
-    core.api_config.server_key=''
+    core.api_config.server_key='invalidkey'
     parameters = generate_param_min()
     err = ''
     try:
@@ -251,7 +251,7 @@ def test_core_api_charge_fail_401():
         err = e
     assert 'MidtransAPIError' in err.__class__.__name__
     assert '401' in err.message
-    assert 'unauthorized' in err.message
+    assert 'authorized' in err.message
 
 def test_core_api_charge_fail_empty_param():
     core = generate_core_api_instance()

--- a/tests/test_snap.py
+++ b/tests/test_snap.py
@@ -105,6 +105,18 @@ def test_snap_exception_MidtransAPIError():
     assert isinstance(err.api_response_dict, dict)
     assert isinstance(err.http_status_code,int)
 
+def test_snap_create_transaction_min_with_custom_headers_via_setter():
+    snap = generate_snap_instance()
+    snap.api_config.custom_headers = {
+        'X-Override-Notification':'https://example.org'
+    }
+    param = generate_param_min()
+    param['transaction_details']['order_id'] = reused_order_id
+    transaction = snap.create_transaction(param)
+    assert isinstance(transaction, dict)
+    assert is_str(transaction['token'])
+    assert is_str(transaction['redirect_url'])
+
 # ======== HELPER FUNCTIONS BELOW ======== #
 def generate_snap_instance():
     snap = midtransclient.Snap(is_production=False,

--- a/tests/test_snap.py
+++ b/tests/test_snap.py
@@ -211,7 +211,7 @@ def generate_param_max():
             "finish": "https://demo.midtrans.com"
         },
         "expiry": {
-            "start_time": "2020-12-20 18:11:08 +0700",
+            "start_time": "2030-12-20 18:11:08 +0700",
             "unit": "minutes",
             "duration": 1
         },


### PR DESCRIPTION
- allow the use of custom header, described on `## 4. Advanced Usage` section on readme.md
- allow the use of proxies, described on `## 4. Advanced Usage` section on readme.md
- bump version to 1.2.0
- some minor enhancements:
  - exclude status code 3xx from being considered as failure req
  - fix outdated/failing tests