### PR TITLE
fix: custom_headers not applied

### DIFF
--- a/midtransclient/http_client.py
+++ b/midtransclient/http_client.py
@@ -45,7 +45,7 @@ class HttpClient(object):
 
         # only merge if custom headers exist
         if custom_headers:
-            headers = {**default_headers, **headers}
+            headers = {**default_headers, **custom_headers}
 
         response_object = self.http_client.request(
             method,

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -1,4 +1,5 @@
 import pytest
+from unittest.mock import patch
 from .helpers import is_str
 from .context import HttpClient
 import datetime
@@ -46,6 +47,35 @@ def test_response_not_json_exception():
             parameters='')
     except Exception as e:
         assert 'JSONDecodeError' in repr(e)
+
+def test_is_custom_headers_applied():
+    http_client = HttpClient()
+
+    custom_headers = {
+        'X-Override-Notification':'https://example.org'
+    }
+
+    # Mock requests
+    with patch('requests.request') as mock_request:
+        # Set status code to 200 to prevent MidtransAPIError
+        mock_request.return_value.status_code = 200 
+
+        # Trigger request
+        http_client.request(method='post',
+        server_key='SB-Mid-server-GwUP_WGbJPXsDzsNEBRs8IYA',
+        request_url='https://app.sandbox.midtrans.com/snap/v1/transactions',
+        parameters=generate_param_min(),
+        custom_headers=custom_headers)
+
+        # Fetch the headers from requests.request arguments
+        headers = mock_request.call_args.kwargs['headers']
+        
+        # Make sure default header still exist
+        assert headers.get('content-type') == 'application/json'
+
+        # Assert custom headers
+        assert 'X-Override-Notification' in headers
+        assert headers.get('X-Override-Notification') == 'https://example.org'
 
 # TODO test GET request
 


### PR DESCRIPTION
I've tried adding `custom_headers` to override URL notifications API as mentioned [here](https://docs.midtrans.com/en/after-payment/http-notification?id=customizing-notification-url-via-api) but it's not applied when testing using sandbox, after looking at the source, I think it's because the `custom_headers` is not merged