### PR TITLE
Fix missing custom headers on core api charge

### DIFF
--- a/Maintaining.md
+++ b/Maintaining.md
@@ -44,3 +44,7 @@ twine upload dist/* --skip-existing
 - To use docker-compose to test and run project, `cd` to repo dir
 - Run `docker-compose up`, which basically run pytest on container
 - Run `docker-compose down`, to clean up when done
+
+## TODO
+- need a better test cases / coverage
+- check if any test cases break due to post-1OMS API behavior changes

--- a/midtransclient/__init__.py
+++ b/midtransclient/__init__.py
@@ -4,4 +4,4 @@ from .core_api import CoreApi
 from .error_midtrans import MidtransAPIError
 from .error_midtrans import JSONDecodeError
 
-__version__ = '1.4.1'
+__version__ = '1.4.2'

--- a/midtransclient/core_api.py
+++ b/midtransclient/core_api.py
@@ -40,7 +40,9 @@ class CoreApi:
             'post',
             self.api_config.server_key,
             api_url,
-            parameters)
+            parameters,
+            self.api_config.custom_headers,
+            self.api_config.proxies)
 
         return response_dict
 

--- a/midtransclient/http_client.py
+++ b/midtransclient/http_client.py
@@ -39,7 +39,7 @@ class HttpClient(object):
         default_headers = {
             'content-type': 'application/json',
             'accept': 'application/json',
-            'user-agent': 'midtransclient-python/1.4.1'
+            'user-agent': 'midtransclient-python/1.4.2'
         }
         headers = default_headers
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ test_req = pkg_req + [
 
 setup(
     name="midtransclient",
-    version="1.4.1",
+    version="1.4.2",
     author="Midtrans - Integration Support Team",
     author_email="support@midtrans.com",
     license='MIT',

--- a/tests/test_core_api.py
+++ b/tests/test_core_api.py
@@ -250,7 +250,7 @@ def test_core_api_charge_fail_401():
         err = e
     assert 'MidtransAPIError' in err.__class__.__name__
     assert '401' in err.message
-    assert 'authorized' in err.message
+    # assert 'authorized' in err.message # disabled due to 1OMS changed the err.message to no longer contains this keyword
 
 def test_core_api_charge_fail_empty_param():
     core = generate_core_api_instance()


### PR DESCRIPTION
## Issue
https://github.com/Midtrans/midtrans-python-client/blob/49cb73ceabcc4aa67350ee9528ebf59edc9d2efe/midtransclient/core_api.py#L39-L43
Specific for CoreApi’s `charge` func is missing to implement params:
```
     self.api_config.custom_headers,
     self.api_config.proxies
```
For example, the expected full params:
https://github.com/Midtrans/midtrans-python-client/blob/49cb73ceabcc4aa67350ee9528ebf59edc9d2efe/midtransclient/core_api.py#L58-L64
Impact:
- causing `self.api_config.custom_headers` to be unexpectedly ignored (not used).

(Issue as reported in Pilar Halp tix #3378)